### PR TITLE
print "reconnecting" instead of silently failing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,9 @@ export default class Dagger extends EventEmitter {
           resolve(...args)
         }
       })
+      this._client.on('reconnect', error => {
+        console.log('reconnecting...')
+      })
     })
 
     // mqtt client events


### PR DESCRIPTION
I was stuck for a while with no visual feedback, because I accidentally tried to connect to `mqtts://` instead of `mqtt://`. This PR is to prevent this 